### PR TITLE
Supress userwarning: label 'included' not exported

### DIFF
--- a/asreviewcontrib/datatools/stack.py
+++ b/asreviewcontrib/datatools/stack.py
@@ -1,4 +1,5 @@
 import argparse
+import warnings
 from pathlib import Path
 
 import pandas as pd
@@ -30,7 +31,10 @@ def vstack(output_file, input_files):
     df_vstacked = pd.concat(list_dfs).reset_index(drop=True)
     as_vstacked = ASReviewData(df=df_vstacked)
 
-    as_vstacked.to_file(output_file)
+    # supress warning about certain columns not exported to .ris output
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        as_vstacked.to_file(output_file)
 
 
 def _parse_arguments_vstack():


### PR DESCRIPTION
When stacking 2 ris datasets the following (innocent) userwarning may occur:
```
c:\>asreview data stack output.ris dataset_1.ris dataset_2.ris

C:\Python310\lib\site-packages\rispy\writer.py:114: UserWarning: label `included` not exported
  warnings.warn(UserWarning(f"label `{label}` not exported"))
```

This PR supresses the warning: same code as used in compose to supress this same warning.