### PR TITLE
Fix typo in sample tool example

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ asreview data snowball input_dataset.csv output_dataset.csv --backward --email m
 This datatool is used to sample old, random and new records from your dataset by using the `asreview data sample` command. The sampled records are then stored in an output file. This can be useful for detecting concept drift, meaning that the words used for certain concepts change over time. This script assumes that the dataset includes a column named `publication_year`. An example would be:
 
 ```bash
-asreview data sample input_dataset.xlsx output_dataset.xslx 50
+asreview data sample input_dataset.xlsx output_dataset.xlsx 50
 ```
 This samples the `50` oldest and `50` newest records from `input_dataset.xlsx` and samples `50` records randomly (without overlap from the old and new partitions!). The resulting 150 records are written to `output_dataset.xlsx`.
 


### PR DESCRIPTION
Example usage of sample datatool showed '.xslx' file extension instead of '.xlsx'. 
Thanks to @RayFit for pointing this out https://github.com/asreview/asreview/discussions/1775#discussioncomment-10075882